### PR TITLE
PoC: topojson-pyの動作/出力確認

### DIFF
--- a/csv2geojson/parser.py
+++ b/csv2geojson/parser.py
@@ -4,6 +4,7 @@ import pathlib
 import shutil
 from collections import OrderedDict
 from urllib.parse import quote
+import topojson as tp
 
 import pandas as pd
 import numpy as np
@@ -128,6 +129,17 @@ def write_geojson(dest, df: pd.DataFrame, debug=False):
         else:
             # 本番用GeoJSONはデータサイズ削減のため、minifyして出力
             json.dump(feature_collection, f, ensure_ascii=False, separators=(',', ':'))
+
+    dest = str(dest).replace('.geojson', '.top.json')
+    with open(dest, 'w', encoding='utf-8') as f:
+        if debug:
+            # デバッグ用GeoJSONは読みやすいように、prettyして出力
+            text = tp.Topology(feature_collection, prequantize=False).to_json()
+            json.dump(text, f, ensure_ascii=False, indent=4)
+        else:
+            # 本番用GeoJSONはデータサイズ削減のため、minifyして出力
+            text = tp.Topology(feature_collection, prequantize=False).to_json()
+            json.dump(text, f, ensure_ascii=False, separators=(',', ':'))
 
 
 class Csv2GeoJSON:

--- a/poetry.lock
+++ b/poetry.lock
@@ -77,6 +77,19 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "shapely"
+version = "1.7.1"
+description = "Geometric objects, predicates, and operations"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+all = ["numpy", "pytest", "pytest-cov"]
+test = ["pytest", "pytest-cov"]
+vectorized = ["numpy"]
+
+[[package]]
 name = "six"
 version = "1.15.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -84,10 +97,25 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
+[[package]]
+name = "topojson"
+version = "1.0"
+description = "topojson - a powerful library to encode geographic data as topology in Python!🌍"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+numpy = "*"
+shapely = "*"
+
+[package.extras]
+dev = ["shapely (>=1.7a2)", "geojson", "simplification", "pyshp", "fiona (>=1.8.6)", "geopandas", "altair", "ipywidgets"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.10"
-content-hash = "e228e1e0d8ec23609c870cf99180ea9d6ea61388515750a2a5bcd4aa93e22ec3"
+content-hash = "bd26269dc81b812bd22082e73274a0babfc75bfd43692526f88efa2cfd7074e4"
 
 [metadata.files]
 colorama = [
@@ -175,7 +203,34 @@ pytz = [
     {file = "pytz-2020.4-py2.py3-none-any.whl", hash = "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"},
     {file = "pytz-2020.4.tar.gz", hash = "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268"},
 ]
+shapely = [
+    {file = "Shapely-1.7.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4c10f317e379cc404f8fc510cd9982d5d3e7ba13a9cfd39aa251d894c6366798"},
+    {file = "Shapely-1.7.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:17df66e87d0fe0193910aeaa938c99f0b04f67b430edb8adae01e7be557b141b"},
+    {file = "Shapely-1.7.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:da38ed3d65b8091447dc3717e5218cc336d20303b77b0634b261bc5c1aa2bae8"},
+    {file = "Shapely-1.7.1-cp35-cp35m-win32.whl", hash = "sha256:8e7659dd994792a0aad8fb80439f59055a21163e236faf2f9823beb63a380e19"},
+    {file = "Shapely-1.7.1-cp35-cp35m-win_amd64.whl", hash = "sha256:791477edb422692e7dc351c5ed6530eb0e949a31b45569946619a0d9cd5f53cb"},
+    {file = "Shapely-1.7.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e3afccf0437edc108eef1e2bb9cc4c7073e7705924eb4cd0bf7715cd1ef0ce1b"},
+    {file = "Shapely-1.7.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8f15b6ce67dcc05b61f19c689b60f3fe58550ba994290ff8332f711f5aaa9840"},
+    {file = "Shapely-1.7.1-cp36-cp36m-win32.whl", hash = "sha256:60e5b2282619249dbe8dc5266d781cc7d7fb1b27fa49f8241f2167672ad26719"},
+    {file = "Shapely-1.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:de618e67b64a51a0768d26a9963ecd7d338a2cf6e9e7582d2385f88ad005b3d1"},
+    {file = "Shapely-1.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:182716ffb500d114b5d1b75d7fd9d14b7d3414cef3c38c0490534cc9ce20981a"},
+    {file = "Shapely-1.7.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4f3c59f6dbf86a9fc293546de492f5e07344e045f9333f3a753f2dda903c45d1"},
+    {file = "Shapely-1.7.1-cp37-cp37m-win32.whl", hash = "sha256:6871acba8fbe744efa4f9f34e726d070bfbf9bffb356a8f6d64557846324232b"},
+    {file = "Shapely-1.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:35be1c5d869966569d3dfd4ec31832d7c780e9df760e1fe52131105685941891"},
+    {file = "Shapely-1.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:052eb5b9ba756808a7825e8a8020fb146ec489dd5c919e7d139014775411e688"},
+    {file = "Shapely-1.7.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:90a3e2ae0d6d7d50ff2370ba168fbd416a53e7d8448410758c5d6a5920646c1d"},
+    {file = "Shapely-1.7.1-cp38-cp38-win32.whl", hash = "sha256:a3774516c8a83abfd1ddffb8b6ec1b0935d7fe6ea0ff5c31a18bfdae567b4eba"},
+    {file = "Shapely-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:6593026cd3f5daaea12bcc51ae5c979318070fefee210e7990cb8ac2364e79a1"},
+    {file = "Shapely-1.7.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b40cc7bb089ae4aa9ddba1db900b4cd1bce3925d2a4b5837b639e49de054784f"},
+    {file = "Shapely-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2df5260d0f2983309776cb41bfa85c464ec07018d88c0ecfca23d40bfadae2f1"},
+    {file = "Shapely-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:a5c3a50d823c192f32615a2a6920e8c046b09e07a58eba220407335a9cd2e8ea"},
+    {file = "Shapely-1.7.1.tar.gz", hash = "sha256:1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129"},
+]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+topojson = [
+    {file = "topojson-1.0-py2.py3-none-any.whl", hash = "sha256:6e83aeae7f1ece18c96f62f01619f94443c333b4257048b4abbd61d8ebe1fe96"},
+    {file = "topojson-1.0.tar.gz", hash = "sha256:e370259e872bd45535f1495fae6c041c3693d82e6f1db8983aaa3d51ca6b15b7"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ pandas = "^1.1.4"
 logzero = "^1.6.3"
 geojson = "^2.5.0"
 posuto = "^0.2.1"
+topojson = "^1.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
# 概要

GitHubが[geojson以外にもtopojson形式に対応](https://docs.github.com/ja/free-pro-team@latest/github/managing-files-in-a-repository/mapping-geojson-files-on-github)しているとのことで、topojsonの出力用ライブラリであるhttps://mattijn.github.io/topojson/ の動作確認を行ったもの。

```
$ docker-compose build
$ docker-compose run csv2geojson python main.py --target akita
(略)

$ ls -al data/output/akita 
total 7984
drwxr-xr-x  9 terukizm  staff     288 12 15 23:52 .
drwxr-xr-x  5 terukizm  staff     160 12 15 23:52 ..
drwxr-xr-x  6 terukizm  staff     192 12 15 23:52 _debug
-rw-r--r--  1 terukizm  staff    1600 12 15 23:52 _error.json
-rw-r--r--  1 terukizm  staff  791941 12 15 23:52 all.geojson
-rw-r--r--  1 terukizm  staff  969566 12 15 23:52 all.top.json
-rw-r--r--  1 terukizm  staff  791941 12 15 23:52 genre10.geojson
-rw-r--r--  1 terukizm  staff  969566 12 15 23:52 genre10.top.json
-rw-r--r--  1 terukizm  staff  550984 12 15 23:52 normalized.csv
```